### PR TITLE
fix: allow manifest to load on non-prod environments

### DIFF
--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
@@ -46,6 +46,7 @@ function common_design_subtheme_preprocess_html(&$vars) {
   // Define manifest file.
   $manifest = [
     'rel' => 'manifest',
+    'crossorigin' => 'use-credentials',
     'href' => '/' . $theme_path . '/manifest.json',
   ];
 


### PR DESCRIPTION
Since we use basic auth on our dev/stage, this attribute allows the manifest to load without popping up an auth box or worse, silently failing.

Refs: NUM-4