### PR TITLE
infra: Add the Elastic APM to the experimental numbers site.

### DIFF
--- a/docker/99-elastic-apm-custom.ini
+++ b/docker/99-elastic-apm-custom.ini
@@ -1,0 +1,19 @@
+; This file contains the various settings for the Elastic APM PHP agent. For
+; further details refers to the following URL:
+; https://www.elastic.co/guide/en/apm/agent/php/current/configuration-reference.html
+;
+
+[elastic]
+elastic_apm.enabled = ${PHP_ELASTIC_APM_ENABLED}
+;elastic_apm.api_key = "REPLACE_WITH_API_KEY"
+elastic_apm.environment = "${PHP_ELASTIC_APM_ENVIRONMENT}"
+elastic_apm.log_level = "INFO"
+elastic_apm.log_level_stderr = "INFO"
+elastic_apm.secret_token = "${PHP_ELASTIC_APM_TOKEN}"
+;elastic_apm.server_timeout = "30s"
+elastic_apm.server_url = "${PHP_ELASTIC_APM_SERVER}"
+elastic_apm.service_name = "${PHP_ELASTIC_APM_SERVICE}"
+elastic_apm.service_version = ${GIT_SHA}
+;elastic_apm.transaction_max_spans = 500
+;elastic_apm.transaction_sample_rate = 1.0
+;elastic_apm.verify_server_cert = true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN rm -rf ./vendor && \
     # Update composer to avoid issues with missing drupal files.
     # @see https://github.com/drupal-composer/drupal-project/issues/282
     composer selfupdate && \
-    composer install --no-interaction
+    composer install --no-interaction --no-dev
 
 # Copy settings to default site location.
 RUN cp -a docker/settings.php docker/services.yml docker/memcache.services.yml html/sites/default
@@ -50,3 +50,9 @@ COPY --from=builder /srv/www/vendor /srv/www/vendor/
 COPY --from=builder /srv/www/composer.json /srv/www/composer.json
 COPY --from=builder /srv/www/composer.patches.json /srv/www/composer.patches.json
 COPY --from=builder /srv/www/composer.lock /srv/www/composer.lock
+COPY --from=builder /srv/www/docker/99-elastic-apm-custom.ini /tmp/99-elastic-apm-custom.ini
+
+RUN  curl -L -o /tmp/apm-agent-php_1.6.1_all.apk https://github.com/elastic/apm-agent-php/releases/download/v1.6.1/apm-agent-php_1.6.1_all.apk && \
+     apk add --allow-untrusted /tmp/apm-agent-php_1.6.1_all.apk && \
+     rm -f /tmp/apm-agent.apk && \
+     mv -f /tmp/99-elastic-apm-custom.ini /etc/php8/conf.d/99-elastic-apm-custom.ini


### PR DESCRIPTION
This way, we will get some actual data. APM config is managed via Ansible.

Refs: OPS-8708