### PR TITLE
NUM-40 Indent ToC items when wrapping

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/rw-toc/num-toc.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-toc/num-toc.css
@@ -22,6 +22,7 @@
 }
 
 .rw-toc a {
+  display: inline-block;
   padding-inline-start: 16px;
 }
 


### PR DESCRIPTION
chore: add inline-block display to TOC anchors so indent when wrapping

Refs: NUM-40

![Selection_182](https://user-images.githubusercontent.com/1835923/197528246-e0d499b9-b533-4ab2-a5e3-1114b38e5c54.png)

