### PR TITLE
fix: Work around NFS file locks on cache clear by not deleting directories.

### DIFF
--- a/PATCHES/3250315-google-tag-nfs-locks-4.patch
+++ b/PATCHES/3250315-google-tag-nfs-locks-4.patch
@@ -1,0 +1,58 @@
+diff --git a/src/Entity/ContainerManager.php b/src/Entity/ContainerManager.php
+index 80fe83e..4f0264f 100644
+--- a/src/Entity/ContainerManager.php
++++ b/src/Entity/ContainerManager.php
+@@ -240,7 +240,7 @@ class ContainerManager implements ContainerManagerInterface {
+       $directory = $this->config->get('uri');
+       if (!empty($directory)) {
+         // Remove any stale files (e.g. module update or machine name change).
+-        return $this->fileSystem->deleteRecursive($directory . '/google_tag');
++        return $this->deleteFilesRecursive($directory . '/google_tag');
+       }
+     }
+
+@@ -266,7 +266,7 @@ class ContainerManager implements ContainerManagerInterface {
+     $directory = $container->snippetDirectory();
+     $result = TRUE;
+     if (!empty($directory) && is_dir($directory)) {
+-      $result = $this->fileSystem->deleteRecursive($directory);
++      $result = $this->deleteFilesRecursive($directory);
+     }
+
+     $args = ['@count' => count($types), '%container' => $container->get('label')];
+@@ -310,4 +310,35 @@ class ContainerManager implements ContainerManagerInterface {
+     return TRUE;
+   }
+
++
++  /**
++   * Helper that recursively deletes files under a directory.
++   *
++   * This is a simplified version of FileSystem::deleteRecursive() that skips
++   * skips directories. This means we module will not error out on NFS file
++   * locks when trying to delete files that are open on other nodes and also
++   * will not need to re-create directories after each cache clear.
++   *
++   * @param $path
++   *   The directory whose contents to delete.
++   *
++   */
++  private function deleteFilesRecursive($path) {
++    if (is_dir($path)) {
++      $dir = dir($path);
++      while (($entry = $dir->read()) !== FALSE) {
++        if ($entry == '.' || $entry == '..') {
++          continue;
++        }
++        $entry_path = $path . '/' . $entry;
++        $this->deleteFilesRecursive($entry_path);
++      }
++      return $dir->close();
++    }
++    else {
++      return $this->fileSystem->delete($path);
++    }
++    return FALSE;
++  }
++
+ }

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -10,6 +10,9 @@
         "drupal/layout_paragraphs" : {
             "Async translation - https://www.drupal.org/project/layout_paragraphs/issues/3178277": "./PATCHES/3178277-6.patch"
         },
+        "drupal/google_tag": {
+            "Error during cache rebuild when assets are stored on NFS": "./PATCHES/3250315-google-tag-nfs-locks-4.patch"
+        },
         "drupal/group": {
             "https://www.drupal.org/project/subgroup/issues/3163044#comment-14499262": "https://www.drupal.org/files/issues/2022-05-04/i3278723.patch",
             "https://www.drupal.org/project/group/issues/3305840": "https://www.drupal.org/files/issues/2022-08-25/group-3294949-2.patch",


### PR DESCRIPTION
This makes production deploys not fail on NFS file licks when the google_tag assets are refreshed.

See https://www.drupal.org/node/3250315