### PR TITLE
chore: bump php version for periodic updates

### DIFF
--- a/.github/workflows/composer-update.yml
+++ b/.github/workflows/composer-update.yml
@@ -17,6 +17,6 @@ jobs:
         patch_branch: 'develop'
         patch_packages: 'drupal/*'
         patch_maintainers: ${{ secrets.DRUPAL_MAINTAINERS }}
+        php_version: '8.1'
         slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
         slack_channel_name: ${{ secrets.SLACK_CHANNEL }}
-        flowdock_token: ${{ secrets.FLOWDOCK_TOKEN }}


### PR DESCRIPTION
Php version was bumped as part of the group module update. This keeps the periodic updates working too.

Also removes the flowdock token.