### PR TITLE
chore: update patch so it applies cleanly

### DIFF
--- a/composer.patches.json
+++ b/composer.patches.json
@@ -1,7 +1,7 @@
 {
     "patches": {
         "drupal/core" : {
-            "https://www.drupal.org/project/drupal/issues/2544110": "https://www.drupal.org/files/issues/2022-12-01/2544110-146.patch",
+            "https://www.drupal.org/project/drupal/issues/2544110": "https://www.drupal.org/files/issues/2023-02-28/2544110-149.patch",
             "Include database SSL/TLS info on status report": "./PATCHES/mysql-ssl-status.patch"
         },
         "drupal/csp": {


### PR DESCRIPTION
Refs: OPS-9111

A very tiny change - the previous patch applies fine with `git apply` but fails when run through github actions when run locally. The updated patch is the same apart from some line numbers.

Trying it locally, the patch fails to apply with this change too, but I'd like to try it using the 'develop' branch.