### PR TITLE
chore: update to tests, without running the tests themselves which are

### DIFF
--- a/.github/workflows/composer-update.yml
+++ b/.github/workflows/composer-update.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  update:
     runs-on: ubuntu-latest
     steps:
     - name: Update The Thing

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,13 +7,35 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout Code
+        id: checkout
+        uses: actions/checkout@v3
+
+      - name: Extract PHP Version
+        id: php
+        uses: docker://ghcr.io/un-ocha/actions:extract-php-version-main
+        with:
+          docker_file: 'docker/Dockerfile'
+          docker_image: 'public.ecr.aws/unocha/php-k8s'
+
       - name: Setup PHP with PECL extension
         uses: shivammathur/setup-php@v2
+        if: ${{ !env.ACT }}
         with:
-          php-version: 8.1
+          php-version: ${{ steps.php.outputs.php_version }}
           tools: composer
         env:
           fail-fast: true
+
+      - name: Setup PHP with PECL extension
+        uses: shivammathur/setup-php@v2
+        if: ${{ env.ACT }}
+        with:
+          php-version: ${{ steps.php.outputs.php_version }}
+          tools: composer
+        env:
+          fail-fast: true
+          runner: self-hosted
 
       - name: Software versions
         id: versions
@@ -21,10 +43,6 @@ jobs:
         with:
           run: |
             php --version && composer --version
-
-      - name: Checkout Code
-        id: checkout
-        uses: actions/checkout@v3
 
       - name: Composer Validate
         id: validate
@@ -46,7 +64,8 @@ jobs:
 
       - name: Configure AWS Credentials
         id: aws
-        uses: aws-actions/configure-aws-credentials@v1
+        if: ${{ !env.ACT }}
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
@@ -54,6 +73,7 @@ jobs:
 
       - name: Login to Public ECR
         id: aws-login
+        if: ${{ !env.ACT }}
         uses: docker/login-action@v2.1.0
         with:
           registry: public.ecr.aws
@@ -76,19 +96,10 @@ jobs:
         uses: cafuego/command-output@main
         with:
           run: |
-            docker-compose -f tests/docker-compose.yml up -d
+            docker compose -f tests/docker-compose.yml up -d
             sleep 10
             docker ps -a
-            docker-compose -f tests/docker-compose.yml exec -w /srv/www -T drupal composer install
-        env:
-          fail-fast: true
-
-      - name: Install Environment
-        id: install
-        uses: cafuego/command-output@main
-        with:
-          run: |
-            docker-compose -f tests/docker-compose.yml exec -T drupal drush -y si --existing-config
+            docker compose -f tests/docker-compose.yml exec -w /srv/www -T drupal composer install
         env:
           fail-fast: true
 
@@ -97,12 +108,64 @@ jobs:
         uses: cafuego/command-output@main
         with:
           run: |
-            docker-compose -f tests/docker-compose.yml exec -u appuser -w /srv/www -T drupal phpcs -p --report=full --standard=phpcs.xml ./html/modules/custom
+            docker compose -f tests/docker-compose.yml exec -u appuser -w /srv/www -T drupal phpcs -p --report=full --standard=phpcs.xml ./html/modules/custom
         env:
           fail-fast: true
 
+      - name: Install Environment
+        id: install
+        uses: cafuego/command-output@main
+        with:
+          run: |
+            docker compose -f tests/docker-compose.yml exec -T drupal drush -y si --existing-config
+        env:
+          fail-fast: true
+
+      # - name: Run tests
+      #   id: tests
+      #   uses: cafuego/command-output@main
+      #   if: ${{ !env.ACT }}
+      #   with:
+      #     run: |
+      #       docker compose -f tests/docker-compose.yml exec -T drupal drush -y cim
+      #       docker compose -f tests/docker-compose.yml exec -T drupal drush -y en dblog
+      #       docker compose -f tests/docker-compose.yml exec -T drupal chmod -R 777 /srv/www/html/sites/default/files /srv/www/html/sites/default/private
+      #       docker compose -f tests/docker-compose.yml exec -T drupal mkdir -p /srv/www/html/build/logs
+      #       docker compose -f tests/docker-compose.yml exec -T drupal chmod -R 777 /srv/www/html/build/logs
+      #       docker compose -f tests/docker-compose.yml exec -T -w /srv/www -e XDEBUG_MODE=coverage -e BROWSERTEST_OUTPUT_DIRECTORY=/srv/www/html/sites/default/files/browser_output -e DTT_BASE_URL=http://127.0.0.1 drupal ./vendor/bin/phpunit --coverage-clover /srv/www/html/build/logs/clover.xml --debug
+      #       docker cp "$(docker compose -f tests/docker-compose.yml ps -q drupal)":/srv/www/html/build/logs/clover.xml .
+      #   env:
+      #     fail-fast: true
+
+      # - name: Run tests
+      #   id: tests
+      #   uses: cafuego/command-output@main
+      #   if: ${{ env.ACT }}
+      #   with:
+      #     run: |
+      #       docker compose -f tests/docker-compose.yml exec -T drupal drush -y cim
+      #       docker compose -f tests/docker-compose.yml exec -T drupal drush -y en dblog
+      #       docker compose -f tests/docker-compose.yml exec -T drupal chmod -R 777 /srv/www/html/sites/default/files /srv/www/html/sites/default/private
+      #       docker compose -f tests/docker-compose.yml exec -T drupal mkdir -p /srv/www/html/build/logs
+      #       docker compose -f tests/docker-compose.yml exec -T drupal chmod -R 777 /srv/www/html/build/logs
+      #       docker compose -f tests/docker-compose.yml exec -T -w /srv/www -e BROWSERTEST_OUTPUT_DIRECTORY=/srv/www/html/sites/default/files/browser_output -e DTT_BASE_URL=http://127.0.0.1 drupal ./vendor/bin/phpunit --debug
+      #   env:
+      #     fail-fast: true
+
+      # - name: Monitor coverage
+      #   uses: slavcodev/coverage-monitor-action@v1
+      #   if: ${{ !env.ACT }}
+      #   with:
+      #     github_token: ${{ secrets.GITHUB_TOKEN }}
+      #     coverage_path: "clover.xml"
+      #     threshold_alert: 10
+      #     threshold_warning: 50
+      #     threshold_metric: "lines"
+      #     comment_footer: false
+
       - name: Post Comment
         uses: actions/github-script@v6
+        if: ${{ !env.ACT }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -130,7 +193,7 @@ jobs:
 
       - name: Slack Success Notification
         id: slack_success
-        if: success()
+        if: ${{ !env.ACT && success() }}
         uses: slackapi/slack-github-action@v1.23.0
         with:
           channel-id: '${{ secrets.SLACK_CHANNEL }}'
@@ -157,7 +220,7 @@ jobs:
 
       - name: Slack Failure Notification
         id: slack_failure
-        if: failure()
+        if: ${{ !env.ACT && failure() }}
         uses: slackapi/slack-github-action@v1.23.0
         with:
           channel-id: '${{ secrets.SLACK_CHANNEL }}'
@@ -181,3 +244,13 @@ jobs:
             }
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      - name: Clean up
+        id: docker-clean-up
+        if: ${{ env.ACT }}
+        uses: cafuego/command-output@main
+        with:
+          run: |
+            docker compose -f tests/docker-compose.yml down
+        env:
+          fail-fast: true

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,10 +18,10 @@
     <!-- Do not limit the amount of memory tests take to run. -->
     <ini name="memory_limit" value="-1"/>
     <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
-    <env name="DTT_BASE_URL" value="http://hrinfo-site.docksal.site/"/>
+    <env name="DTT_BASE_URL" value="http://numbers-test-site/"/>
     <env name="DTT_API_URL" value="http://localhost:9222"/>
     <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
-    <env name="SIMPLETEST_BASE_URL" value="http://hrinfo-site.docksal.site/"/>
+    <env name="SIMPLETEST_BASE_URL" value="http://numbers-test-site/"/>
     <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
     <env name="SIMPLETEST_DB" value="mysql://user:user@db/test"/>
     <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->


### PR DESCRIPTION
out of date

Refs: OPS-9006

This mainly lets tests be run locally - note that the code to run the unit tests is commented out as the tests seem to be out of date and are all failing. I've created https://humanitarian.atlassian.net/browse/NUM-81 to address that.

Also includes the 'PHP extract version' action.